### PR TITLE
Tags without namespaces

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -43,7 +43,7 @@ class Tag < ApplicationRecord
   acts_as_tenant(:tenant)
 
   def to_tag_string
-    File.join("/", namespace, name).tap { |string| string << "=#{value}" if value.present? }
+    "/#{namespace}/#{name}".tap { |string| string << "=#{value}" if value.present? }
   end
 
   def self.create!(attributes)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -58,8 +58,9 @@ class Tag < ApplicationRecord
     raise ArgumentError, "must start with /" unless tag_string.start_with?("/")
 
     {}.tap do |tag_values|
-      keyspace, tag_values[:value]                    = tag_string.split("=")
-      _nil, tag_values[:namespace], tag_values[:name] = keyspace.split("/", 3)
+      keyspace, tag_values[:value]       = tag_string.split("=")
+      _nil, namespace, tag_values[:name] = keyspace.split("/", 3)
+      tag_values[:namespace]             = namespace.presence
     end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,15 +1,33 @@
 describe Tag do
-  describe "#to_tag_string" do
-    it "with a value" do
-      expect(Tag.new(:namespace => "test_namespace", :name => "some_key", :value => "123abc").to_tag_string).to eq("/test_namespace/some_key=123abc")
+  REVERSIBLE_TEST_CASES = {
+    {:name => "some_key",             :namespace => "test_namespace", :value => "123abc"} => "/test_namespace/some_key=123abc",
+    {:name => "some_key",             :namespace => "test_namespace", :value => nil}      => "/test_namespace/some_key",
+    {:name => "some_key",             :namespace => nil,              :value => "123abc"} => "//some_key=123abc",
+    {:name => "some_key",             :namespace => nil,              :value => nil}      => "//some_key",
+    {:name => "some_key/another_key", :namespace => "test_namespace", :value => "123abc"} => "/test_namespace/some_key/another_key=123abc",
+    {:name => "some_key/another_key", :namespace => "test_namespace", :value => nil}      => "/test_namespace/some_key/another_key",
+    {:name => "some_key/another_key", :namespace => nil,              :value => "123abc"} => "//some_key/another_key=123abc",
+    {:name => "some_key/another_key", :namespace => nil,              :value => nil}      => "//some_key/another_key",
+  }.freeze
+
+  NON_REVERSIBLE_TEST_CASES = {
+    {:name => "some_key", :namespace => "test_namespace", :value => ""} => "/test_namespace/some_key",
+    {:name => "some_key", :namespace => nil,              :value => ""} => "//some_key",
+  }.freeze
+
+  it "#to_tag_string" do
+    REVERSIBLE_TEST_CASES.merge(NON_REVERSIBLE_TEST_CASES).each do |properties, string|
+      expect(Tag.new(properties).to_tag_string).to eq(string)
+    end
+  end
+
+  it ".parse" do
+    REVERSIBLE_TEST_CASES.each do |properties, string|
+      expect(Tag.parse(string)).to eq(properties)
     end
 
-    it "with nil value" do
-      expect(Tag.new(:namespace => "test_namespace", :name => "some_key", :value => nil).to_tag_string).to eq("/test_namespace/some_key")
-    end
-
-    it "with empty value" do
-      expect(Tag.new(:namespace => "test_namespace", :name => "some_key", :value => "").to_tag_string).to eq("/test_namespace/some_key")
+    NON_REVERSIBLE_TEST_CASES.each do |properties, string|
+      expect(Tag.parse(string)).to eq(properties.merge(:value => nil))
     end
   end
 end


### PR DESCRIPTION
Add more test cases and ensure that tags from `#to_tag_string` can be parsed by `.parse` (with and without a namespace)