### PR TITLE
Security Group-Network association

### DIFF
--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -9,6 +9,7 @@ class Network < ApplicationRecord
   belongs_to :subscription, :optional => true
   belongs_to :orchestration_stack, :optional => true
 
+  has_many :security_groups
   has_many :subnets
 
   acts_as_tenant(:tenant)

--- a/app/models/security_group.rb
+++ b/app/models/security_group.rb
@@ -8,6 +8,7 @@ class SecurityGroup < ApplicationRecord
   belongs_to :source_region, :optional => true
   belongs_to :subscription, :optional => true
   belongs_to :orchestration_stack, :optional => true
+  belongs_to :network, :optional => true
 
   has_many :vm_security_groups
   has_many :vms, :through => :vm_security_groups


### PR DESCRIPTION
Added missing associations 1:N between Security Group and Network.
Needed for openapi generator (resp. `rake openapi:generate` in topological-inventory-persister)