### PR TITLE
Add reference to tenant in the tag join classes

### DIFF
--- a/app/models/cluster_tag.rb
+++ b/app/models/cluster_tag.rb
@@ -1,4 +1,6 @@
 class ClusterTag < ApplicationRecord
   belongs_to :cluster
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/concerns/act_as_taggable_on.rb
+++ b/app/models/concerns/act_as_taggable_on.rb
@@ -61,6 +61,10 @@ module ActAsTaggableOn
         self.class.tagging_relation_name.to_s.classify.constantize
       end
     end
+
+    tenant_klass = ActsAsTenant.tenant_klass
+    join_klass = tagging_relation_name.to_s.singularize.classify.safe_constantize
+    join_klass.before_validation(:on => :create) { |i| i.send("#{tenant_klass}=", i.tag.send(tenant_klass)) }
   end
 
   def tagged_with(tag_name, options = {})

--- a/app/models/container_group_tag.rb
+++ b/app/models/container_group_tag.rb
@@ -1,4 +1,6 @@
 class ContainerGroupTag < ApplicationRecord
   belongs_to :container_group
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/container_image_tag.rb
+++ b/app/models/container_image_tag.rb
@@ -1,4 +1,6 @@
 class ContainerImageTag < ApplicationRecord
   belongs_to :container_image
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/container_node_tag.rb
+++ b/app/models/container_node_tag.rb
@@ -1,4 +1,6 @@
 class ContainerNodeTag < ApplicationRecord
   belongs_to :container_node
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/container_project_tag.rb
+++ b/app/models/container_project_tag.rb
@@ -1,4 +1,6 @@
 class ContainerProjectTag < ApplicationRecord
   belongs_to :container_project
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/container_template_tag.rb
+++ b/app/models/container_template_tag.rb
@@ -1,4 +1,6 @@
 class ContainerTemplateTag < ApplicationRecord
   belongs_to :container_template
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/datastore_tag.rb
+++ b/app/models/datastore_tag.rb
@@ -1,4 +1,6 @@
 class DatastoreTag < ApplicationRecord
   belongs_to :datastore
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/host_tag.rb
+++ b/app/models/host_tag.rb
@@ -1,4 +1,6 @@
 class HostTag < ApplicationRecord
   belongs_to :host
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/ipaddress_tag.rb
+++ b/app/models/ipaddress_tag.rb
@@ -1,4 +1,6 @@
 class IpaddressTag < ApplicationRecord
   belongs_to :ipaddress
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/network_adapter_tag.rb
+++ b/app/models/network_adapter_tag.rb
@@ -1,4 +1,6 @@
 class NetworkAdapterTag < ApplicationRecord
   belongs_to :network_adapter
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/network_tag.rb
+++ b/app/models/network_tag.rb
@@ -1,4 +1,6 @@
 class NetworkTag < ApplicationRecord
   belongs_to :network
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/reservation_tag.rb
+++ b/app/models/reservation_tag.rb
@@ -1,4 +1,6 @@
 class ReservationTag < ApplicationRecord
   belongs_to :reservation
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/security_group_tag.rb
+++ b/app/models/security_group_tag.rb
@@ -1,4 +1,6 @@
 class SecurityGroupTag < ApplicationRecord
   belongs_to :security_group
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/service_inventory_tag.rb
+++ b/app/models/service_inventory_tag.rb
@@ -1,4 +1,6 @@
 class ServiceInventoryTag < ApplicationRecord
   belongs_to :service_inventory
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/service_offering_tag.rb
+++ b/app/models/service_offering_tag.rb
@@ -1,4 +1,6 @@
 class ServiceOfferingTag < ApplicationRecord
   belongs_to :service_offering
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/subnet_tag.rb
+++ b/app/models/subnet_tag.rb
@@ -1,4 +1,6 @@
 class SubnetTag < ApplicationRecord
   belongs_to :subnet
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/app/models/vm_tag.rb
+++ b/app/models/vm_tag.rb
@@ -1,4 +1,6 @@
 class VmTag < ApplicationRecord
   belongs_to :vm
   belongs_to :tag
+  belongs_to :tenant
+  acts_as_tenant(:tenant)
 end

--- a/db/migrate/20200122181811_add_tenant_to_join_tables.rb
+++ b/db/migrate/20200122181811_add_tenant_to_join_tables.rb
@@ -1,0 +1,134 @@
+class AddTenantToJoinTables < ActiveRecord::Migration[5.2]
+  class Tag < ActiveRecord::Base
+  end
+
+  class ClusterTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ContainerGroupTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ContainerImageTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ContainerNodeTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ContainerProjectTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ContainerTemplateTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class DatastoreTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class HostTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class IpaddressTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class NetworkAdapterTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class NetworkTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ReservationTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class SecurityGroupTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ServiceInventoryTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class ServiceOfferingTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class SubnetTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  class VmTag < ActiveRecord::Base
+    belongs_to :tag
+  end
+
+  def up
+    add_reference :cluster_tags,            :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :container_group_tags,    :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :container_image_tags,    :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :container_node_tags,     :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :container_project_tags,  :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :container_template_tags, :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :datastore_tags,          :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :host_tags,               :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :ipaddress_tags,          :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :network_adapter_tags,    :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :network_tags,            :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :reservation_tags,        :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :security_group_tags,     :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :service_inventory_tags,  :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :service_offering_tags,   :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :subnet_tags,             :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    add_reference :vm_tags,                 :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+
+    [
+      ClusterTag,
+      ContainerGroupTag,
+      ContainerImageTag,
+      ContainerNodeTag,
+      ContainerProjectTag,
+      ContainerTemplateTag,
+      DatastoreTag,
+      HostTag,
+      IpaddressTag,
+      NetworkAdapterTag,
+      NetworkTag,
+      ReservationTag,
+      SecurityGroupTag,
+      ServiceInventoryTag,
+      ServiceOfferingTag,
+      SubnetTag,
+      VmTag,
+    ].each do |klass|
+      klass.find_each { |i| i.update(:tenant_id => i.tag.tenant_id) }
+    end
+  end
+
+  def down
+    remove_reference :cluster_tags,            :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :container_group_tags,    :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :container_image_tags,    :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :container_node_tags,     :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :container_project_tags,  :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :container_template_tags, :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :datastore_tags,          :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :host_tags,               :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :ipaddress_tags,          :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :network_adapter_tags,    :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :network_tags,            :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :reservation_tags,        :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :security_group_tags,     :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :service_inventory_tags,  :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :service_offering_tags,   :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :subnet_tags,             :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+    remove_reference :vm_tags,                 :tenant, :type => :bigint, :index => true, :foreign_key => {:on_delete => :cascade}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_18_181501) do
+ActiveRecord::Schema.define(version: 2020_01_22_181811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,9 +32,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "cluster_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["cluster_id"], name: "index_cluster_tags_on_cluster_id"
     t.index ["last_seen_at"], name: "index_cluster_tags_on_last_seen_at"
     t.index ["tag_id", "cluster_id"], name: "index_cluster_tags_on_tag_id_and_cluster_id", unique: true
+    t.index ["tenant_id"], name: "index_cluster_tags_on_tenant_id"
   end
 
   create_table "clusters", force: :cascade do |t|
@@ -64,9 +66,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "container_group_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["container_group_id", "tag_id"], name: "uniq_index_on_container_group_id_tag_id", unique: true
     t.index ["last_seen_at"], name: "index_container_group_tags_on_last_seen_at"
     t.index ["tag_id"], name: "index_container_group_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_container_group_tags_on_tenant_id"
   end
 
   create_table "container_groups", force: :cascade do |t|
@@ -100,9 +104,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "container_image_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["container_image_id", "tag_id"], name: "uniq_index_on_container_image_id_tag_id", unique: true
     t.index ["last_seen_at"], name: "index_container_image_tags_on_last_seen_at"
     t.index ["tag_id"], name: "index_container_image_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_container_image_tags_on_tenant_id"
   end
 
   create_table "container_images", force: :cascade do |t|
@@ -131,9 +137,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "container_node_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["container_node_id", "tag_id"], name: "uniq_index_on_container_node_id_tag_id", unique: true
     t.index ["last_seen_at"], name: "index_container_node_tags_on_last_seen_at"
     t.index ["tag_id"], name: "index_container_node_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_container_node_tags_on_tenant_id"
   end
 
   create_table "container_nodes", force: :cascade do |t|
@@ -175,9 +183,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "container_project_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["container_project_id", "tag_id"], name: "uniq_index_on_container_project_id_tag_id", unique: true
     t.index ["last_seen_at"], name: "index_container_project_tags_on_last_seen_at"
     t.index ["tag_id"], name: "index_container_project_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_container_project_tags_on_tenant_id"
   end
 
   create_table "container_projects", force: :cascade do |t|
@@ -234,9 +244,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "container_template_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["container_template_id", "tag_id"], name: "uniq_index_on_container_template_id_tag_id", unique: true
     t.index ["last_seen_at"], name: "index_container_template_tags_on_last_seen_at"
     t.index ["tag_id"], name: "index_container_template_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_container_template_tags_on_tenant_id"
   end
 
   create_table "container_templates", force: :cascade do |t|
@@ -301,9 +313,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "datastore_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["datastore_id"], name: "index_datastore_tags_on_datastore_id"
     t.index ["last_seen_at"], name: "index_datastore_tags_on_last_seen_at"
     t.index ["tag_id", "datastore_id"], name: "index_datastore_tags_on_tag_id_and_datastore_id", unique: true
+    t.index ["tenant_id"], name: "index_datastore_tags_on_tenant_id"
   end
 
   create_table "datastores", force: :cascade do |t|
@@ -356,9 +370,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "host_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["host_id"], name: "index_host_tags_on_host_id"
     t.index ["last_seen_at"], name: "index_host_tags_on_last_seen_at"
     t.index ["tag_id", "host_id"], name: "index_host_tags_on_tag_id_and_host_id", unique: true
+    t.index ["tenant_id"], name: "index_host_tags_on_tenant_id"
   end
 
   create_table "hosts", force: :cascade do |t|
@@ -395,9 +411,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "ipaddress_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["ipaddress_id"], name: "index_ipaddress_tags_on_ipaddress_id"
     t.index ["last_seen_at"], name: "index_ipaddress_tags_on_last_seen_at"
     t.index ["tag_id", "ipaddress_id"], name: "index_ipaddress_tags_on_tag_id_and_ipaddress_id", unique: true
+    t.index ["tenant_id"], name: "index_ipaddress_tags_on_tenant_id"
   end
 
   create_table "ipaddresses", force: :cascade do |t|
@@ -436,9 +454,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "network_adapter_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_network_adapter_tags_on_last_seen_at"
     t.index ["network_adapter_id"], name: "index_network_adapter_tags_on_network_adapter_id"
     t.index ["tag_id", "network_adapter_id"], name: "index_network_adapter_tags_on_tag_id_and_network_adapter_id", unique: true
+    t.index ["tenant_id"], name: "index_network_adapter_tags_on_tenant_id"
   end
 
   create_table "network_adapters", force: :cascade do |t|
@@ -475,9 +495,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "network_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_network_tags_on_last_seen_at"
     t.index ["network_id"], name: "index_network_tags_on_network_id"
     t.index ["tag_id", "network_id"], name: "index_network_tags_on_tag_id_and_network_id", unique: true
+    t.index ["tenant_id"], name: "index_network_tags_on_tenant_id"
   end
 
   create_table "networks", force: :cascade do |t|
@@ -567,9 +589,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "reservation_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_reservation_tags_on_last_seen_at"
     t.index ["reservation_id"], name: "index_reservation_tags_on_reservation_id"
     t.index ["tag_id", "reservation_id"], name: "index_reservation_tags_on_tag_id_and_reservation_id", unique: true
+    t.index ["tenant_id"], name: "index_reservation_tags_on_tenant_id"
   end
 
   create_table "reservations", force: :cascade do |t|
@@ -605,9 +629,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "security_group_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_security_group_tags_on_last_seen_at"
     t.index ["security_group_id"], name: "index_security_group_tags_on_security_group_id"
     t.index ["tag_id", "security_group_id"], name: "index_security_group_tags_on_tag_id_and_security_group_id", unique: true
+    t.index ["tenant_id"], name: "index_security_group_tags_on_tenant_id"
   end
 
   create_table "security_groups", force: :cascade do |t|
@@ -754,9 +780,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "service_inventory_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_service_inventory_tags_on_last_seen_at"
     t.index ["service_inventory_id"], name: "index_service_inventory_tags_on_service_inventory_id"
     t.index ["tag_id", "service_inventory_id"], name: "service_inventories_tags_unique_index", unique: true
+    t.index ["tenant_id"], name: "index_service_inventory_tags_on_tenant_id"
   end
 
   create_table "service_offering_icons", id: :serial, force: :cascade do |t|
@@ -805,9 +833,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "service_offering_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_service_offering_tags_on_last_seen_at"
     t.index ["service_offering_id", "tag_id"], name: "uniq_index_on_service_offering_id_tag_id", unique: true
     t.index ["tag_id"], name: "index_service_offering_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_service_offering_tags_on_tenant_id"
   end
 
   create_table "service_offerings", force: :cascade do |t|
@@ -910,9 +940,11 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "subnet_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_subnet_tags_on_last_seen_at"
     t.index ["subnet_id"], name: "index_subnet_tags_on_subnet_id"
     t.index ["tag_id", "subnet_id"], name: "index_subnet_tags_on_tag_id_and_subnet_id", unique: true
+    t.index ["tenant_id"], name: "index_subnet_tags_on_tenant_id"
   end
 
   create_table "subnets", force: :cascade do |t|
@@ -1007,8 +1039,10 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
     t.bigint "tag_id", null: false
     t.bigint "vm_id", null: false
     t.datetime "last_seen_at"
+    t.bigint "tenant_id"
     t.index ["last_seen_at"], name: "index_vm_tags_on_last_seen_at"
     t.index ["tag_id"], name: "index_vm_tags_on_tag_id"
+    t.index ["tenant_id"], name: "index_vm_tags_on_tenant_id"
     t.index ["vm_id", "tag_id"], name: "uniq_index_on_vm_id_tag_id", unique: true
   end
 
@@ -1116,24 +1150,29 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
 
   add_foreign_key "cluster_tags", "clusters", on_delete: :cascade
   add_foreign_key "cluster_tags", "tags", on_delete: :cascade
+  add_foreign_key "cluster_tags", "tenants", on_delete: :cascade
   add_foreign_key "clusters", "sources", on_delete: :cascade
   add_foreign_key "clusters", "tenants", on_delete: :cascade
   add_foreign_key "container_group_tags", "container_groups", on_delete: :cascade
   add_foreign_key "container_group_tags", "tags", on_delete: :cascade
+  add_foreign_key "container_group_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_groups", "container_nodes", on_delete: :cascade
   add_foreign_key "container_groups", "container_projects", on_delete: :cascade
   add_foreign_key "container_groups", "sources", on_delete: :cascade
   add_foreign_key "container_groups", "tenants", on_delete: :cascade
   add_foreign_key "container_image_tags", "container_images", on_delete: :cascade
   add_foreign_key "container_image_tags", "tags", on_delete: :cascade
+  add_foreign_key "container_image_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_images", "sources", on_delete: :cascade
   add_foreign_key "container_images", "tenants", on_delete: :cascade
   add_foreign_key "container_node_tags", "container_nodes", on_delete: :cascade
   add_foreign_key "container_node_tags", "tags", on_delete: :cascade
+  add_foreign_key "container_node_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_nodes", "sources", on_delete: :cascade
   add_foreign_key "container_nodes", "tenants", on_delete: :cascade
   add_foreign_key "container_project_tags", "container_projects", on_delete: :cascade
   add_foreign_key "container_project_tags", "tags", on_delete: :cascade
+  add_foreign_key "container_project_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_projects", "sources", on_delete: :cascade
   add_foreign_key "container_projects", "tenants", on_delete: :cascade
   add_foreign_key "container_resource_quotas", "container_projects", on_delete: :cascade
@@ -1141,6 +1180,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "container_resource_quotas", "tenants", on_delete: :cascade
   add_foreign_key "container_template_tags", "container_templates", on_delete: :cascade
   add_foreign_key "container_template_tags", "tags", on_delete: :cascade
+  add_foreign_key "container_template_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_templates", "container_projects", on_delete: :cascade
   add_foreign_key "container_templates", "sources", on_delete: :cascade
   add_foreign_key "container_templates", "tenants", on_delete: :cascade
@@ -1151,17 +1191,20 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "datastore_mounts", "hosts", on_delete: :cascade
   add_foreign_key "datastore_tags", "datastores", on_delete: :cascade
   add_foreign_key "datastore_tags", "tags", on_delete: :cascade
+  add_foreign_key "datastore_tags", "tenants", on_delete: :cascade
   add_foreign_key "datastores", "sources", on_delete: :cascade
   add_foreign_key "datastores", "tenants", on_delete: :cascade
   add_foreign_key "flavors", "sources", on_delete: :cascade
   add_foreign_key "flavors", "tenants", on_delete: :cascade
   add_foreign_key "host_tags", "hosts", on_delete: :cascade
   add_foreign_key "host_tags", "tags", on_delete: :cascade
+  add_foreign_key "host_tags", "tenants", on_delete: :cascade
   add_foreign_key "hosts", "clusters", on_delete: :nullify
   add_foreign_key "hosts", "sources", on_delete: :cascade
   add_foreign_key "hosts", "tenants", on_delete: :cascade
   add_foreign_key "ipaddress_tags", "ipaddresses", on_delete: :cascade
   add_foreign_key "ipaddress_tags", "tags", on_delete: :cascade
+  add_foreign_key "ipaddress_tags", "tenants", on_delete: :cascade
   add_foreign_key "ipaddresses", "network_adapters", on_delete: :cascade
   add_foreign_key "ipaddresses", "orchestration_stacks", on_delete: :cascade
   add_foreign_key "ipaddresses", "source_regions", on_delete: :cascade
@@ -1171,6 +1214,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "ipaddresses", "tenants", on_delete: :cascade
   add_foreign_key "network_adapter_tags", "network_adapters", on_delete: :cascade
   add_foreign_key "network_adapter_tags", "tags", on_delete: :cascade
+  add_foreign_key "network_adapter_tags", "tenants", on_delete: :cascade
   add_foreign_key "network_adapters", "orchestration_stacks", on_delete: :cascade
   add_foreign_key "network_adapters", "source_regions", on_delete: :cascade
   add_foreign_key "network_adapters", "sources", on_delete: :cascade
@@ -1178,6 +1222,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "network_adapters", "tenants", on_delete: :cascade
   add_foreign_key "network_tags", "networks", on_delete: :cascade
   add_foreign_key "network_tags", "tags", on_delete: :cascade
+  add_foreign_key "network_tags", "tenants", on_delete: :cascade
   add_foreign_key "networks", "orchestration_stacks", on_delete: :cascade
   add_foreign_key "networks", "source_regions", on_delete: :cascade
   add_foreign_key "networks", "sources", on_delete: :cascade
@@ -1194,6 +1239,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "refresh_states", "tenants", on_delete: :cascade
   add_foreign_key "reservation_tags", "reservations", on_delete: :cascade
   add_foreign_key "reservation_tags", "tags", on_delete: :cascade
+  add_foreign_key "reservation_tags", "tenants", on_delete: :cascade
   add_foreign_key "reservations", "flavors", on_delete: :cascade
   add_foreign_key "reservations", "source_regions", on_delete: :cascade
   add_foreign_key "reservations", "sources", on_delete: :cascade
@@ -1201,6 +1247,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "reservations", "tenants", on_delete: :cascade
   add_foreign_key "security_group_tags", "security_groups", on_delete: :cascade
   add_foreign_key "security_group_tags", "tags", on_delete: :cascade
+  add_foreign_key "security_group_tags", "tenants", on_delete: :cascade
   add_foreign_key "security_groups", "networks", on_delete: :cascade
   add_foreign_key "security_groups", "orchestration_stacks", on_delete: :cascade
   add_foreign_key "security_groups", "source_regions", on_delete: :cascade
@@ -1228,6 +1275,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "service_inventories", "tenants", on_delete: :cascade
   add_foreign_key "service_inventory_tags", "service_inventories", on_delete: :cascade
   add_foreign_key "service_inventory_tags", "tags", on_delete: :cascade
+  add_foreign_key "service_inventory_tags", "tenants", on_delete: :cascade
   add_foreign_key "service_offering_icons", "sources", on_delete: :cascade
   add_foreign_key "service_offering_icons", "tenants", on_delete: :cascade
   add_foreign_key "service_offering_nodes", "service_credentials", on_delete: :nullify
@@ -1238,6 +1286,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "service_offering_nodes", "tenants", on_delete: :cascade
   add_foreign_key "service_offering_tags", "service_offerings", on_delete: :cascade
   add_foreign_key "service_offering_tags", "tags", on_delete: :cascade
+  add_foreign_key "service_offering_tags", "tenants", on_delete: :cascade
   add_foreign_key "service_offerings", "service_credentials", on_delete: :nullify
   add_foreign_key "service_offerings", "service_inventories", on_delete: :nullify
   add_foreign_key "service_offerings", "service_offering_icons", on_delete: :nullify
@@ -1255,6 +1304,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "sources", "tenants", on_delete: :cascade
   add_foreign_key "subnet_tags", "subnets", on_delete: :cascade
   add_foreign_key "subnet_tags", "tags", on_delete: :cascade
+  add_foreign_key "subnet_tags", "tenants", on_delete: :cascade
   add_foreign_key "subnets", "networks", on_delete: :cascade
   add_foreign_key "subnets", "orchestration_stacks", on_delete: :cascade
   add_foreign_key "subnets", "source_regions", on_delete: :cascade
@@ -1268,6 +1318,7 @@ ActiveRecord::Schema.define(version: 2019_11_18_181501) do
   add_foreign_key "vm_security_groups", "security_groups", on_delete: :cascade
   add_foreign_key "vm_security_groups", "vms", on_delete: :cascade
   add_foreign_key "vm_tags", "tags", on_delete: :cascade
+  add_foreign_key "vm_tags", "tenants", on_delete: :cascade
   add_foreign_key "vm_tags", "vms", on_delete: :cascade
   add_foreign_key "vms", "flavors", on_delete: :nullify
   add_foreign_key "vms", "hosts", on_delete: :nullify


### PR DESCRIPTION
Previously querying the join table based on tag attributes wasn't working when tenancy was enabled.  The query was incorrectly using a different id as the tenant_id in a select.

Specifically see $1 in this line:
```sql
SELECT COUNT(*) FROM "container_node_tags" WHERE ((SELECT "tags"."namespace" FROM "tags" WHERE "tags"."tenant_id" = $1 AND "tags"."id" = "container_node_tags"."tag_id") = 'test') AND "container_node_tags"."container_node_id" = $1  [["container_node_id", 1174]]
```

From:
```
    [----] D, [2020-01-21T16:56:01.518858 #163322:11a4608] DEBUG -- :   Tenant Load (0.2ms)  SELECT  "tenants".* FROM "tenants" WHERE "tenants"."external_tenant" = $1 LIMIT $2  [["external_tenant", "177"], ["LIMIT", 1]]
    [----] D, [2020-01-21T16:56:01.520881 #163322:11a4608] DEBUG -- :   ContainerNode Load (0.2ms)  SELECT  "container_nodes".* FROM "container_nodes" WHERE "container_nodes"."tenant_id" = $1 AND "container_nodes"."id" = $2 LIMIT $3  [["tenant_id", 21806], ["id", 1174], ["LIMIT", 1]]
    [----] D, [2020-01-21T16:56:01.523646 #163322:11a4608] DEBUG -- :    (0.4ms)  SELECT COUNT(*) FROM "container_node_tags" WHERE ((SELECT "tags"."namespace" FROM "tags" WHERE "tags"."tenant_id" = $1 AND "tags"."id" = "container_node_tags"."tag_id") = 'test') AND "container_node_tags"."container_node_id" = $1  [["container_node_id", 1174]]
    [----] D, [2020-01-21T16:56:01.524642 #163322:11a4608] DEBUG -- :   ContainerNodeTag Load (0.4ms)  SELECT  "container_node_tags".* FROM "container_node_tags" WHERE ((SELECT "tags"."namespace" FROM "tags" WHERE "tags"."tenant_id" = $1 AND "tags"."id" = "container_node_tags"."tag_id") = 'test') AND "container_node_tags"."container_node_id" = $1 ORDER BY "container_node_tags"."id" ASC LIMIT $2 OFFSET $3  [["container_node_id", 1174], ["LIMIT", 100], ["OFFSET", 0]]
```