### PR TITLE
Deduplicate tag join relation declarations

### DIFF
--- a/app/models/cluster_tag.rb
+++ b/app/models/cluster_tag.rb
@@ -1,6 +1,2 @@
 class ClusterTag < ApplicationRecord
-  belongs_to :cluster
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/concerns/act_as_taggable_on.rb
+++ b/app/models/concerns/act_as_taggable_on.rb
@@ -65,6 +65,10 @@ module ActAsTaggableOn
     tenant_klass = ActsAsTenant.tenant_klass
     join_klass = tagging_relation_name.to_s.singularize.classify.safe_constantize
     join_klass.before_validation(:on => :create) { |i| i.send("#{tenant_klass}=", i.tag.send(tenant_klass)) }
+    join_klass.belongs_to(name.underscore.to_sym)
+    join_klass.belongs_to(:tag)
+    join_klass.belongs_to(tenant_klass)
+    join_klass.acts_as_tenant(tenant_klass)
   end
 
   def tagged_with(tag_name, options = {})

--- a/app/models/container_group_tag.rb
+++ b/app/models/container_group_tag.rb
@@ -1,6 +1,2 @@
 class ContainerGroupTag < ApplicationRecord
-  belongs_to :container_group
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_image_tag.rb
+++ b/app/models/container_image_tag.rb
@@ -1,6 +1,2 @@
 class ContainerImageTag < ApplicationRecord
-  belongs_to :container_image
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_node_tag.rb
+++ b/app/models/container_node_tag.rb
@@ -1,6 +1,2 @@
 class ContainerNodeTag < ApplicationRecord
-  belongs_to :container_node
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_project_tag.rb
+++ b/app/models/container_project_tag.rb
@@ -1,6 +1,2 @@
 class ContainerProjectTag < ApplicationRecord
-  belongs_to :container_project
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_template_tag.rb
+++ b/app/models/container_template_tag.rb
@@ -1,6 +1,2 @@
 class ContainerTemplateTag < ApplicationRecord
-  belongs_to :container_template
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/datastore_tag.rb
+++ b/app/models/datastore_tag.rb
@@ -1,6 +1,2 @@
 class DatastoreTag < ApplicationRecord
-  belongs_to :datastore
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/host_tag.rb
+++ b/app/models/host_tag.rb
@@ -1,6 +1,2 @@
 class HostTag < ApplicationRecord
-  belongs_to :host
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/ipaddress_tag.rb
+++ b/app/models/ipaddress_tag.rb
@@ -1,6 +1,2 @@
 class IpaddressTag < ApplicationRecord
-  belongs_to :ipaddress
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/network_adapter_tag.rb
+++ b/app/models/network_adapter_tag.rb
@@ -1,6 +1,2 @@
 class NetworkAdapterTag < ApplicationRecord
-  belongs_to :network_adapter
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/network_tag.rb
+++ b/app/models/network_tag.rb
@@ -1,6 +1,2 @@
 class NetworkTag < ApplicationRecord
-  belongs_to :network
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/reservation_tag.rb
+++ b/app/models/reservation_tag.rb
@@ -1,6 +1,2 @@
 class ReservationTag < ApplicationRecord
-  belongs_to :reservation
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/security_group_tag.rb
+++ b/app/models/security_group_tag.rb
@@ -1,6 +1,2 @@
 class SecurityGroupTag < ApplicationRecord
-  belongs_to :security_group
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/service_inventory_tag.rb
+++ b/app/models/service_inventory_tag.rb
@@ -1,6 +1,2 @@
 class ServiceInventoryTag < ApplicationRecord
-  belongs_to :service_inventory
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/service_offering_tag.rb
+++ b/app/models/service_offering_tag.rb
@@ -1,6 +1,2 @@
 class ServiceOfferingTag < ApplicationRecord
-  belongs_to :service_offering
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/subnet_tag.rb
+++ b/app/models/subnet_tag.rb
@@ -1,6 +1,2 @@
 class SubnetTag < ApplicationRecord
-  belongs_to :subnet
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end

--- a/app/models/vm_tag.rb
+++ b/app/models/vm_tag.rb
@@ -1,6 +1,2 @@
 class VmTag < ApplicationRecord
-  belongs_to :vm
-  belongs_to :tag
-  belongs_to :tenant
-  acts_as_tenant(:tenant)
 end


### PR DESCRIPTION
The only downside is that the relations don't exist until the other class is loaded because we have eagerloading disabled.

```ruby
$ rails c
Loading development environment (Rails 5.2.4.1)
irb(main):001:0> pp ClusterTag.reflect_on_all_associations
[]
=> []

irb(main):002:0> Cluster
=> Cluster (call 'Cluster.connection' to establish a connection)

irb(main):003:0> pp ClusterTag.reflect_on_all_associations; nil
[#<ActiveRecord::Reflection::BelongsToReflection:0x0000000005c31630
  @active_record=
   ClusterTag (call 'ClusterTag.connection' to establish a connection),
  @association_scope_cache=
   #<Concurrent::Map:0x0000000005c31388 entries=0 default_proc=nil>,
  @constructable=true,
  @foreign_key="cluster_id",
  @foreign_type=nil,
  @klass=nil,
  @name=:cluster,
  @options={},
  @plural_name="clusters",
  @scope=nil,
  @type=nil>,
 #<ActiveRecord::Reflection::BelongsToReflection:0x0000000005c2f268
  @active_record=
   ClusterTag (call 'ClusterTag.connection' to establish a connection),
  @association_scope_cache=
   #<Concurrent::Map:0x0000000005c2f0d8 entries=0 default_proc=nil>,
  @constructable=true,
  @foreign_key="tag_id",
  @foreign_type=nil,
  @klass=nil,
  @name=:tag,
  @options={},
  @plural_name="tags",
  @scope=nil,
  @type=nil>,
 #<ActiveRecord::Reflection::BelongsToReflection:0x0000000005c25c90
  @active_record=
   ClusterTag (call 'ClusterTag.connection' to establish a connection),
  @association_scope_cache=
   #<Concurrent::Map:0x0000000005c25b78 entries=0 default_proc=nil>,
  @constructable=true,
  @foreign_type=nil,
  @klass=nil,
  @name=:tenant,
  @options={},
  @plural_name="tenants",
  @scope=nil,
  @type=nil>]
=> nil
```