### PR TITLE
Add missing has_many relations for ipaddresses

### DIFF
--- a/app/models/source_region.rb
+++ b/app/models/source_region.rb
@@ -6,6 +6,7 @@ class SourceRegion < ApplicationRecord
   belongs_to :tenant
   belongs_to :source
 
+  has_many :ipaddresses
   has_many :network_adapters
   has_many :networks
   has_many :orchestration_stacks

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,6 +6,7 @@ class Subscription < ApplicationRecord
   belongs_to :tenant
   belongs_to :source
 
+  has_many :ipaddresses
   has_many :network_adapters
   has_many :networks
   has_many :orchestration_stacks

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -9,6 +9,7 @@ class Tenant < ApplicationRecord
   has_many :container_templates
   has_many :datastores
   has_many :flavors
+  has_many :ipaddresses
   has_many :network_adapters
   has_many :networks
   has_many :orchestration_stacks


### PR DESCRIPTION
The belongs_to is already there on the other side.  Found while looking into the has many through subcollection issue.