### PR TITLE
Refresh Tracking Timestamps

### DIFF
--- a/db/migrate/20200317082640_add_tracking_timestamps_to_refresh_state.rb
+++ b/db/migrate/20200317082640_add_tracking_timestamps_to_refresh_state.rb
@@ -1,0 +1,6 @@
+class AddTrackingTimestampsToRefreshState < ActiveRecord::Migration[5.2]
+  def change
+    add_column :refresh_states, :started_at, :timestamp
+    add_column :refresh_states, :finished_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_13_141215) do
+ActiveRecord::Schema.define(version: 2020_03_17_082640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -635,6 +635,8 @@ ActiveRecord::Schema.define(version: 2020_03_13_141215) do
     t.string "error_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "started_at"
+    t.datetime "finished_at"
     t.index ["source_id", "uuid"], name: "index_refresh_states_on_source_id_and_uuid", unique: true
     t.index ["tenant_id"], name: "index_refresh_states_on_tenant_id"
   end

--- a/lib/topological_inventory/schema/base.rb
+++ b/lib/topological_inventory/schema/base.rb
@@ -4,14 +4,6 @@ require "inventory_refresh/persister"
 module TopologicalInventory
   module Schema
     class Base < InventoryRefresh::Persister
-      attr_accessor :refresh_time_tracking
-
-      def initialize(manager)
-        self.refresh_time_tracking = {:persister_started_at => Time.now.utc.to_datetime.to_s}
-        super(manager)
-      end
-
-      # TODO: add time_tracking?
       def to_hash
         {
           "schema": {
@@ -21,29 +13,13 @@ module TopologicalInventory
         }.merge(super)
       end
 
-      class << self
-        def from_hash(persister_data, manager)
-          persister = super(persister_data, manager)
-          %i[
-            refresh_state_part_collected_at
-            refresh_state_part_sent_at
-            refresh_state_started_at
-            refresh_state_sent_at
-            ingress_api_sent_at
-          ].each do |timestamp_name|
-            persister.refresh_time_tracking[timestamp_name] = persister_data[timestamp_name.to_s]
-          end
-          persister
-        end
+      def self.klass_for(name)
+        klass_name = "TopologicalInventory::Schema::#{name}"
+        klass      = klass_name.safe_constantize
 
-        def klass_for(name)
-          klass_name = "TopologicalInventory::Schema::#{name}"
-          klass = klass_name.safe_constantize
-
-          # sometimes autoloader is confused and loads class with another namespace
-          # checks whether it loads what we want
-          klass if klass.to_s == klass_name
-        end
+        # sometimes autoloader is confused and loads class with another namespace
+        # checks whether it loads what we want
+        klass if klass.to_s == klass_name
       end
     end
   end

--- a/lib/topological_inventory/schema/base.rb
+++ b/lib/topological_inventory/schema/base.rb
@@ -4,11 +4,14 @@ require "inventory_refresh/persister"
 module TopologicalInventory
   module Schema
     class Base < InventoryRefresh::Persister
-      def persist!
-        link_data_to_refresh_state_part
-        super
+      attr_accessor :refresh_time_tracking
+
+      def initialize(manager)
+        self.refresh_time_tracking = {:persister_started_at => Time.now.utc.to_datetime.to_s}
+        super(manager)
       end
 
+      # TODO: add time_tracking?
       def to_hash
         {
           "schema": {
@@ -18,26 +21,28 @@ module TopologicalInventory
         }.merge(super)
       end
 
-      def self.klass_for(name)
-        klass_name = "TopologicalInventory::Schema::#{name}"
-        klass = klass_name.safe_constantize
-
-        # sometimes autoloader is confused and loads class with another namespace
-        # checks whether it loads what we want
-        klass if klass.to_s == klass_name
-      end
-
-      private
-
-      def link_data_to_refresh_state_part
-        refresh_state_part = ::RefreshStatePart.where(:uuid => refresh_state_part_uuid).first
-        if refresh_state_part.present?
-          ics = inventory_collections.select { |ic| ic.data.present? }
-          ics.each do |ic|
-            ic.data.each do |inventory_object|
-              inventory_object.data[:refresh_state_part_id] = refresh_state_part.id
-            end
+      class << self
+        def from_hash(persister_data, manager)
+          persister = super(persister_data, manager)
+          %i[
+            refresh_state_part_collected_at
+            refresh_state_part_sent_at
+            refresh_state_started_at
+            refresh_state_sent_at
+            ingress_api_sent_at
+          ].each do |timestamp_name|
+            persister.refresh_time_tracking[timestamp_name] = persister_data[timestamp_name.to_s]
           end
+          persister
+        end
+
+        def klass_for(name)
+          klass_name = "TopologicalInventory::Schema::#{name}"
+          klass = klass_name.safe_constantize
+
+          # sometimes autoloader is confused and loads class with another namespace
+          # checks whether it loads what we want
+          klass if klass.to_s == klass_name
         end
       end
     end

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_runtime_dependency "acts_as_tenant",    "~> 0.4.4"
-  s.add_runtime_dependency "inventory_refresh", "~> 0.3.2"
+  s.add_runtime_dependency "inventory_refresh", "~> 0.3.4"
   s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.3"
   s.add_runtime_dependency "pg", "> 0"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/52

Adding two timestamps to `RefreshState` model:
- **started_at** - Time of the beginning of collecting one data set [collector part]
- **finished_at** - Time after saving all parts of one data set [persister part]

Note: Linking data to refresh_state_part moved to persister (https://github.com/RedHatInsights/topological_inventory-persister/pull/53)

---

- [x] **depends on** https://github.com/ManageIQ/inventory_refresh/pull/91