### PR TITLE
Updating Task in ServiceInstance custom_save_block

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -77,6 +77,9 @@ class Source < ApplicationRecord
   has_many :volume_attachments, :through => :volumes
   has_many :volume_types
 
+  # Tasks
+  has_many :tasks
+
   ALLOWED_REFRESH_STATUS_VALUES = ["deployed", "quota_limited"].freeze
   validates :refresh_status, :allow_nil => true, :inclusion => {:in => ALLOWED_REFRESH_STATUS_VALUES, :message => "%{value} is not included in #{ALLOWED_REFRESH_STATUS_VALUES}"}
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :tenant
+  belongs_to :source, :optional => true
 
   validates :state,  :inclusion => {:in => %w(pending queued running completed)}
   validates :status, :inclusion => {:in => %w(ok warn error)}

--- a/db/migrate/20200403114310_add_target_and_source_to_task.rb
+++ b/db/migrate/20200403114310_add_target_and_source_to_task.rb
@@ -1,8 +1,10 @@
-class AddTargetToTask < ActiveRecord::Migration[5.2]
+class AddTargetAndSourceToTask < ActiveRecord::Migration[5.2]
   def change
     add_column :tasks, :target_source_ref, :string, :null => true
     add_column :tasks, :target_type, :string, :null => true
 
     add_index :tasks, %i[target_type target_source_ref]
+
+    add_reference :tasks, :source, :index => true, :null => true, :foreign_key => { :on_delete => :nullify }
   end
 end

--- a/db/migrate/20200403114310_add_target_to_task.rb
+++ b/db/migrate/20200403114310_add_target_to_task.rb
@@ -1,0 +1,8 @@
+class AddTargetToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :target_source_ref, :string, :null => true
+    add_column :tasks, :target_type, :string, :null => true
+
+    add_index :tasks, %i[target_type target_source_ref]
+  end
+end

--- a/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
+++ b/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
@@ -1,0 +1,21 @@
+class ExtractTasksSourceRefFromContext < ActiveRecord::Migration[5.2]
+  def up
+    Task.find_in_batches.each do |tasks|
+      tasks.each do |task|
+        source_ref = task.context&.dig('service_instance', 'source_ref')
+        next if source_ref.nil?
+
+        say "Task: #{task.id}, Source ref: #{source_ref}"
+        source_id = task.context&.dig('service_instance', 'source_id')
+
+        task.update_attributes(:target_source_ref => source_ref.to_s,
+                               :target_type       => 'ServiceInstance',
+                               :source_id         => source_id)
+      end
+    end
+  end
+
+  def down
+    Task.update_all(:source_id => nil, :target_type => nil, :target_source_ref => nil)
+  end
+end

--- a/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
+++ b/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
@@ -1,17 +1,15 @@
 class ExtractTasksSourceRefFromContext < ActiveRecord::Migration[5.2]
   def up
-    Task.find_in_batches.each do |tasks|
-      tasks.each do |task|
-        source_ref = task.context&.dig('service_instance', 'source_ref')
-        next if source_ref.nil?
+    Task.find_each do |task|
+      source_ref = task.context&.dig('service_instance', 'source_ref')
+      next if source_ref.nil?
 
-        say "Task: #{task.id}, Source ref: #{source_ref}"
-        source_id = task.context&.dig('service_instance', 'source_id')
+      say "Task: #{task.id}, Source ref: #{source_ref}"
+      source_id = task.context&.dig('service_instance', 'source_id')
 
-        task.update_attributes(:target_source_ref => source_ref.to_s,
-                               :target_type       => 'ServiceInstance',
-                               :source_id         => source_id)
-      end
+      task.update_attributes(:target_source_ref => source_ref.to_s,
+                             :target_type       => 'ServiceInstance',
+                             :source_id         => source_id)
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_03_114310) do
+ActiveRecord::Schema.define(version: 2020_04_14_123737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1189,6 +1189,8 @@ ActiveRecord::Schema.define(version: 2020_04_03_114310) do
     t.datetime "updated_at", null: false
     t.string "target_source_ref"
     t.string "target_type"
+    t.bigint "source_id"
+    t.index ["source_id"], name: "index_tasks_on_source_id"
     t.index ["target_type", "target_source_ref"], name: "index_tasks_on_target_type_and_target_source_ref"
     t.index ["tenant_id"], name: "index_tasks_on_tenant_id"
   end
@@ -1564,6 +1566,7 @@ ActiveRecord::Schema.define(version: 2020_04_03_114310) do
   add_foreign_key "subscriptions", "tenants", on_delete: :cascade
   add_foreign_key "tags", "refresh_state_parts", on_delete: :nullify
   add_foreign_key "tags", "tenants", on_delete: :cascade
+  add_foreign_key "tasks", "sources", on_delete: :nullify
   add_foreign_key "tasks", "tenants", on_delete: :cascade
   add_foreign_key "vm_security_groups", "refresh_state_parts", on_delete: :nullify
   add_foreign_key "vm_security_groups", "security_groups", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_082640) do
+ActiveRecord::Schema.define(version: 2020_04_03_114310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1187,6 +1187,9 @@ ActiveRecord::Schema.define(version: 2020_03_17_082640) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "target_source_ref"
+    t.string "target_type"
+    t.index ["target_type", "target_source_ref"], name: "index_tasks_on_target_type_and_target_source_ref"
     t.index ["tenant_id"], name: "index_tasks_on_tenant_id"
   end
 

--- a/lib/topological_inventory/core/version.rb
+++ b/lib/topological_inventory/core/version.rb
@@ -1,5 +1,5 @@
 module TopologicalInventory
   module Core
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/topological_inventory/schema/default.rb
+++ b/lib/topological_inventory/schema/default.rb
@@ -171,8 +171,7 @@ module TopologicalInventory
               FROM (VALUES :values
               ) AS c(source_ref, state, status, context)
               WHERE t.target_source_ref = c.source_ref
-                AND t.target_type = 'ServiceInstance'
-                AND t.state = 'running';
+                AND t.target_type = 'ServiceInstance';
 SQL
             sql.sub!(':values', sql_update_values.join(','))
 

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_runtime_dependency "acts_as_tenant",    "~> 0.4.4"
-  s.add_runtime_dependency "inventory_refresh", "~> 0.3.4"
+  s.add_runtime_dependency "inventory_refresh", "~> 0.3.5"
   s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.3"
   s.add_runtime_dependency "pg", "> 0"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-ansible_tower/issues/83

Updates _running_ `Tasks` of associated `ServiceInstances`.  
Feature is moved from topological_inventory-ansible_tower operations worker because there isn't timeout.

`Task` extended by `source_id`, `target_source_ref` and `target_type`(`== ServiceInstance`)

Uses custom_save_block for `InventoryCollection :service_instances`.

**Note**: This PR processes Task's status in ansible-tower's specific way. Solved in #188 

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/issues/190 **[must be applied to stable branch first]**
- [ ] **depends on** https://github.com/ManageIQ/inventory_refresh/pull/92 **[must be released to RubyGems]**
---

**Gem version _1.1.0_** 
- [ ] released to **RubyGems**