### PR TITLE
Saving updated tasks to IC

### DIFF
--- a/db/migrate/20200428090420_add_request_id_to_task.rb
+++ b/db/migrate/20200428090420_add_request_id_to_task.rb
@@ -1,0 +1,5 @@
+class AddRequestIdToTask < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :x_rh_insights_request, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_123737) do
+ActiveRecord::Schema.define(version: 2020_04_28_090420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1190,6 +1190,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_123737) do
     t.string "target_source_ref"
     t.string "target_type"
     t.bigint "source_id"
+    t.string "x_rh_insights_request"
     t.index ["source_id"], name: "index_tasks_on_source_id"
     t.index ["target_type", "target_source_ref"], name: "index_tasks_on_target_type_and_target_source_ref"
     t.index ["tenant_id"], name: "index_tasks_on_tenant_id"

--- a/lib/topological_inventory/core/version.rb
+++ b/lib/topological_inventory/core/version.rb
@@ -1,5 +1,5 @@
 module TopologicalInventory
   module Core
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end

--- a/lib/topological_inventory/schema/default.rb
+++ b/lib/topological_inventory/schema/default.rb
@@ -148,10 +148,10 @@ module TopologicalInventory
 
         # Updating Tasks
         # service_instance_tasks_update_by_raw_sql(source)
-        service_instance_tasks_update_by_activerecord(source, src_refs)
+        service_instance_tasks_update_by_activerecord(tasks_collection, source, src_refs)
       end
 
-      def task_update_values(svc_instance_id, external_url, status, task_status, finished_timestamp)
+      def task_update_values(svc_instance_id, source_ref, external_url, status, task_status, finished_timestamp, source_id)
         {
           :state  => finished_timestamp.blank? ? 'running' : 'completed',
           :status => task_status,
@@ -159,6 +159,8 @@ module TopologicalInventory
             :service_instance => {
               :id         => svc_instance_id,
               :job_status => status,
+              :source_id  => source_id,
+              :source_ref => source_ref,
               :url        => external_url
             }
           }
@@ -166,17 +168,22 @@ module TopologicalInventory
       end
 
       # This method is updating one by one using ActiveRecord
-      def service_instance_tasks_update_by_activerecord(source, svc_instances_source_ref)
+      def service_instance_tasks_update_by_activerecord(tasks_collection, source, svc_instances_source_ref)
         service_instances = ServiceInstance.where(:source_id => source.id, :source_ref => svc_instances_source_ref)
         tasks_by_source_ref = Task.where(:state => 'running', :target_type => 'ServiceInstance', :source_id => source.id, :target_source_ref => service_instances.pluck(:source_ref)).index_by(&:target_source_ref)
 
         service_instances.select(:id, :external_url, :source_ref, :extra).find_in_batches do |group|
           ActiveRecord::Base.transaction do
             group.each do |svc_instance|
-              next if tasks_by_source_ref[svc_instance.source_ref].nil?
+              next if (task = tasks_by_source_ref[svc_instance.source_ref]).nil?
 
-              values = task_update_values(svc_instance.id, svc_instance.external_url, svc_instance.extra['status'], svc_instance.extra['task_status'], svc_instance.extra['finished'])
-              tasks_by_source_ref[svc_instance.source_ref].update(values)
+              values = task_update_values(svc_instance.id, svc_instance.source_ref, svc_instance.external_url, svc_instance.extra['status'], svc_instance.extra['task_status'], svc_instance.extra['finished'], source.id)
+              # 1) Updating Task
+              task.update(values)
+
+              # 2) Saving to updated records (will be published in Kafka)
+              # - see topological_inventory-persister:Workflow.send_task_updates_to_queue!
+              tasks_collection.updated_records << values.merge(:id => task.id, :x_rh_insights_request => task.x_rh_insights_request)
             end
           end
         end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-ansible_tower/issues/83

Updated tasks are saved to inventory collections for further processing by Persister's Workflow.

---

**dependent** https://github.com/RedHatInsights/topological_inventory-persister/pull/56

---

**Gem version: 1.1.2**
- [ ] released to **RubyGems**