### PR TITLE
Add check to 4/14 migration to handle legacy string context

### DIFF
--- a/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
+++ b/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
@@ -1,6 +1,11 @@
 class ExtractTasksSourceRefFromContext < ActiveRecord::Migration[5.2]
   def up
     Task.find_each do |task|
+      if task.context.is_a?(String)
+        say "Found legacy data in Task #{task.id}, converting String to Hash..."
+        task.context = JSON.parse(task.context)
+      end
+
       source_ref = task.context&.dig('service_instance', 'source_ref')
       next if source_ref.nil?
 


### PR DESCRIPTION
Apparently theres some older data in the db (from like Sep 2019) that has the `context` column as strings, which would cause the migration on API to blow up.

This handles that so the migrations can continue!

cc @syncrou @slemrmartin @gmcculloug 