### PR TITLE
Store whole forwardable_headers in Task

### DIFF
--- a/db/migrate/20200505101547_add_forwardable_headers_remove_request_id_on_task.rb
+++ b/db/migrate/20200505101547_add_forwardable_headers_remove_request_id_on_task.rb
@@ -1,0 +1,11 @@
+class AddForwardableHeadersRemoveRequestIdOnTask < ActiveRecord::Migration[5.2]
+  def up
+    add_column :tasks, :forwardable_headers, :jsonb
+    remove_column :tasks, :x_rh_insights_request
+  end
+
+  def down
+    add_column :tasks, :x_rh_insights_request, :string
+    remove_column :tasks, :forwardable_headers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_090420) do
+ActiveRecord::Schema.define(version: 2020_05_05_101547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1190,7 +1190,7 @@ ActiveRecord::Schema.define(version: 2020_04_28_090420) do
     t.string "target_source_ref"
     t.string "target_type"
     t.bigint "source_id"
-    t.string "x_rh_insights_request"
+    t.jsonb "forwardable_headers"
     t.index ["source_id"], name: "index_tasks_on_source_id"
     t.index ["target_type", "target_source_ref"], name: "index_tasks_on_target_type_and_target_source_ref"
     t.index ["tenant_id"], name: "index_tasks_on_tenant_id"

--- a/lib/topological_inventory/core/version.rb
+++ b/lib/topological_inventory/core/version.rb
@@ -1,5 +1,5 @@
 module TopologicalInventory
   module Core
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
   end
 end

--- a/lib/topological_inventory/schema/default.rb
+++ b/lib/topological_inventory/schema/default.rb
@@ -183,7 +183,7 @@ module TopologicalInventory
 
               # 2) Saving to updated records (will be published in Kafka)
               # - see topological_inventory-persister:Workflow.send_task_updates_to_queue!
-              tasks_collection.updated_records << values.merge(:id => task.id, :x_rh_insights_request => task.x_rh_insights_request)
+              tasks_collection.updated_records << values.merge(:id => task.id, :forwardable_headers => task.forwardable_headers)
             end
           end
         end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-persister/issues/58

`Insights::API::Common::Request.current_forwardable` is saved in Task instead of x-rh-insights-request-id. To be able to resend it through Kafka in persister

---

**dependent** https://github.com/RedHatInsights/topological_inventory-persister/pull/59
**dependent** https://github.com/RedHatInsights/topological_inventory-api/pull/302

---

**Gem version: 1.1.4**
- [ ] released to **RubyGems**
