### PR TITLE
Adding the 'acts_as_tenant' for RefreshState and RefreshStatePart models

### DIFF
--- a/app/models/refresh_state.rb
+++ b/app/models/refresh_state.rb
@@ -1,6 +1,6 @@
-require 'acts_as_tenant'
-
 class RefreshState < ActiveRecord::Base
+  require 'acts_as_tenant'
+
   belongs_to :source
   belongs_to :tenant
   has_many :refresh_state_parts

--- a/app/models/refresh_state.rb
+++ b/app/models/refresh_state.rb
@@ -1,3 +1,5 @@
+require 'acts_as_tenant'
+
 class RefreshState < ActiveRecord::Base
   belongs_to :source
   belongs_to :tenant

--- a/app/models/refresh_state_part.rb
+++ b/app/models/refresh_state_part.rb
@@ -1,6 +1,6 @@
-require 'acts_as_tenant'
-
 class RefreshStatePart < ActiveRecord::Base
+  require 'acts_as_tenant'
+
   belongs_to :refresh_state
   belongs_to :tenant
 

--- a/app/models/refresh_state_part.rb
+++ b/app/models/refresh_state_part.rb
@@ -1,3 +1,5 @@
+require 'acts_as_tenant'
+
 class RefreshStatePart < ActiveRecord::Base
   belongs_to :refresh_state
   belongs_to :tenant


### PR DESCRIPTION
Adding the `acts_as_tenant` behaviour for RefreshState and RefreshStatePart models, since both of them inherit from the active_record and not from the application_record like rest of the models.