### PR TITLE
bump miq messaging version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2020-09-22
+- bump miq-messaging version for rdkafka changes #TBD
+
 ## [1.1.8]
 - Added artifacts to tasks IC and bulk sql update #207
 - Finishing tasks with archived service_instance #210
@@ -34,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.2] - 2020-04-28
 ### Initial release to rubygems.org
 
-[Unreleased]: https://github.com/RedHatInsights/topological_inventory-core/compare/v1.1.8...HEAD
+[Unreleased]: https://github.com/RedHatInsights/topological_inventory-core/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/RedHatInsights/topological_inventory-core/compare/v1.1.8...v1.2.0
 [1.1.8]: https://github.com/RedHatInsights/topological_inventory-core/compare/v1.1.7...v1.1.8
 [1.1.7]: https://github.com/RedHatInsights/topological_inventory-core/compare/v1.1.6...v1.1.7
 [1.1.6]: https://github.com/RedHatInsights/topological_inventory-core/compare/v1.1.5...v1.1.6

--- a/lib/topological_inventory/core/version.rb
+++ b/lib/topological_inventory/core/version.rb
@@ -1,5 +1,5 @@
 module TopologicalInventory
   module Core
-    VERSION = '1.1.8'
+    VERSION = '1.2.0'
   end
 end

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "acts_as_tenant",    "~> 0.4.4"
   s.add_runtime_dependency "inventory_refresh", "~> 0.3.5"
-  s.add_runtime_dependency "manageiq-messaging", "~> 0.2.0"
+  s.add_runtime_dependency "manageiq-messaging", "~> 1.0.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.3"
   s.add_runtime_dependency "pg", "> 0"
   s.add_runtime_dependency "rails", "~> 5.2.2"

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "acts_as_tenant",    "~> 0.4.4"
   s.add_runtime_dependency "inventory_refresh", "~> 0.3.5"
-  s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
+  s.add_runtime_dependency "manageiq-messaging", "~> 0.2.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.3"
   s.add_runtime_dependency "pg", "> 0"
   s.add_runtime_dependency "rails", "~> 5.2.2"


### PR DESCRIPTION
- bump miq-messaging version for rdkafka changes
- Release version 1.2.0

Bumping the versioning requirement for 1.2.0, that way it requires v0.2.0 of miq-messaging to pull in the rdkafka changes.
