### PR TITLE
Rubocop rules from insights-api-common

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/210

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
