### PR TITLE
Rubocop rules from insights-api-common + yamllint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,9 +2,9 @@
 version: '2'
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 checks:
   argument-count:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,4 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: rubocop-0-69
+    channel: rubocop-1-0

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+ignore: |
+
+extends: relaxed
+
+rules:
+  line-length:
+    max: 120

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -26,8 +26,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "active_record_doctor"
   s.add_development_dependency "rspec-rails", "~>3.8"
-  s.add_development_dependency 'rubocop', '~>0.69.0'
-  s.add_development_dependency 'rubocop-performance', '~>1.3'
+  s.add_development_dependency 'rubocop', '~> 1.0.0'
+  s.add_development_dependency 'rubocop-performance', '~>1.8'
+  s.add_development_dependency 'rubocop-rails', '~> 2.8'
   s.add_development_dependency "simplecov", "~> 0.17.1"
   s.add_development_dependency "webmock"
 end


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* extending #211
* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
