### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Topological Inventory Core
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-core.svg)](https://travis-ci.org/RedHatInsights/topological_inventory-core)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-core.svg)](https://travis-ci.com/RedHatInsights/topological_inventory-core)
 [![Maintainability](https://api.codeclimate.com/v1/badges/34f9bd9412e35c1a36fd/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-core/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/34f9bd9412e35c1a36fd/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-core/test_coverage)
 [![Security](https://hakiri.io/github/RedHatInsights/topological_inventory-core/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-core/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.