### PR TITLE
Added missing index RefreshState:updated_at for DB cleaner

### DIFF
--- a/db/migrate/20210119154616_add_index_to_refresh_state.rb
+++ b/db/migrate/20210119154616_add_index_to_refresh_state.rb
@@ -1,0 +1,5 @@
+class AddIndexToRefreshState < ActiveRecord::Migration[5.2]
+  def change
+    add_index :refresh_states, :updated_at
+  end
+end


### PR DESCRIPTION
Topological-inventory-db-cleaner is using:
`RefreshState.where('updated_at <= ?', threshold).delete_all`

but the db index is missing so it takes ages 

I thought we solved this issue before...