### PR TITLE
Define Task model in migration ExtractTasksSourceRefFromContext

### DIFF
--- a/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
+++ b/db/migrate/20200414123737_extract_tasks_source_ref_from_context.rb
@@ -1,4 +1,6 @@
 class ExtractTasksSourceRefFromContext < ActiveRecord::Migration[5.2]
+  class Task < ActiveRecord::Base; end
+
   def up
     Task.find_each do |task|
       if task.context.is_a?(String)


### PR DESCRIPTION
This change keeps migrations independent  on `app/models`. 
